### PR TITLE
Upgrade the Australian postal code regex parser to the stricter one used by Perl's Regex::Common::zip

### DIFF
--- a/locale/en-AU.js
+++ b/locale/en-AU.js
@@ -3,5 +3,9 @@ var extend = require('cog/extend');
 
 module.exports = function(input, opts) {
   // parse the base address
-  return parser(input, extend({ rePostalCode: /(\d{4})\s*$/ }, opts));
+  return parser(input, extend({ rePostalCode: /((?:[1-8][0-9]|9[0-7]|0?[28]|0?9(?=09))(?:[0-9]{2}))\s*$/ }, opts));
+                                               // Postal codes of the form 'DDDD', with the first
+                                               // two digits 02, 08 or 20-97. Leading 0 may be omitted.
+                                               // 909 and 0909 are valid as well - but no other postal
+                                               // codes starting with 9 or 09.
 };

--- a/test/postalcode-en-AU.js
+++ b/test/postalcode-en-AU.js
@@ -62,3 +62,16 @@ test('8/437 St Kilda Road Melbourne, VIC ', expect({
   "street": "St Kilda Road",
   "regions": ["Melbourne", "VIC"]
 }));
+
+// Check behavior with a failing address
+test('BOOM', expect({
+  "regions": ["BOOM"],
+  postalcode: undefined
+}));
+
+// 9999 is not a valid Australian postal code.
+// If we don't recognize the postal code, it goes in the region field.
+test('Eight Mile Plains 9999', expect({
+  "regions": ["Eight Mile Plains 9999"],
+  postalcode: undefined
+}));


### PR DESCRIPTION

Ref: http://cpansearch.perl.org/src/ABIGAIL/Regexp-Common-2013031301/lib/Regexp/Common/zip.pm

Also, I added some tests with /invalid/ addresses for AU addresses to confirm the behavior in those cases.