### PR TITLE
Stop converting postalcodes and housenumber to integers

### DIFF
--- a/address.js
+++ b/address.js
@@ -69,9 +69,6 @@ proto._extractStreetParts = function(startIndex) {
 
   this.number = numberParts ? numberParts.join('/') : '';
   this.street = streetParts.join(' ').replace(/\,/g, '');
-
-  // parse the number as an integer
-  this.number = reNumeric.test(this.number) ? parseInt(this.number, 10) : this.number;
 };
 
 /**
@@ -150,7 +147,7 @@ proto.extract = function(fieldName, regexes) {
   } // for
 
   // update the field value
-  this[fieldName] = parseInt(value, 10) || value;
+  this[fieldName] = value;
 
   return this;
 };

--- a/test/locale-en-AU.js
+++ b/test/locale-en-AU.js
@@ -7,36 +7,36 @@ function expect(expected) {
 }
 
 test('2649 Logan Road, Eight Mile Plains, QLD 4113', expect({
-  number: 2649,
+  number: '2649',
   street: 'Logan Road',
   regions: ['Eight Mile Plains', 'QLD'],
-  postalcode: 4113
+  postalcode: '4113'
 }));
 
 test('2649 Logan Road Eight Mile Plains, QLD 4113', expect({
-  number: 2649,
+  number: '2649',
   street: 'Logan Road',
   regions: ['Eight Mile Plains', 'QLD'],
-  postalcode: 4113
+  postalcode: '4113'
 }));
 
 test('1 Queen Street, Brisbane 4000', expect({
-  "number": 1,
+  "number": '1',
   "street": "Queen Street",
   "regions": ["Brisbane"],
-  postalcode: 4000
+  postalcode: '4000'
 }));
 
 test('754 Robinson Rd West, Aspley, QLD 4035', expect({
-  number: 754,
+  number: '754',
   street: 'Robinson Rd West',
   regions: ['Aspley', 'QLD'],
-  postalcode: 4035
+  postalcode: '4035'
 }));
 
 test('Sydney 2000', expect({
   "regions": ["Sydney"],
-  postalcode: 2000
+  postalcode: '2000'
 }));
 
 test('Perth', expect({
@@ -44,21 +44,21 @@ test('Perth', expect({
 }));
 
 test('1/135 Ferny Way, Ferny Grove 4054', expect({
-  "unit": 1,
-  "number": 135,
+  "unit": '1',
+  "number": '135',
   "street": "Ferny Way",
   "regions": ["Ferny Grove"],
-  postalcode: 4054
+  postalcode: '4054'
 }));
 
 test('Eight Mile Plains 4113', expect({
   "regions": ["Eight Mile Plains"],
-  postalcode: 4113
+  postalcode: '4113'
 }));
 
 test('8/437 St Kilda Road Melbourne, VIC ', expect({
-  "unit": 8,
-  "number": 437,
+  "unit": '8',
+  "number": '437',
   "street": "St Kilda Road",
   "regions": ["Melbourne", "VIC"]
 }));

--- a/test/locale-en-US.js
+++ b/test/locale-en-US.js
@@ -7,49 +7,49 @@ function expect(expected) {
 }
 
 test('123 Main St, New York, NY 10010', expect({
-  number: 123,
+  number: '123',
   street: 'Main St',
   state: 'NY',
   regions: ['New York'],
-  postalcode: 10010
+  postalcode: '10010'
 }));
 
 test('123 Main St New York, NY 10010', expect({
-  number: 123,
+  number: '123',
   street: 'Main St',
   state: 'NY',
   regions: ['New York'],
-  postalcode: 10010
+  postalcode: '10010'
 }));
 
 test('123 Main St New York NY 10010', expect({
-  number: 123,
+  number: '123',
   street: 'Main St',
   state: 'NY',
   regions: ['New York'],
-  postalcode: 10010
+  postalcode: '10010'
 }));
 
 test('123 E 21st st, Brooklyn NY 11020', expect({
-  "number": 123,
+  "number": '123',
   "street": "E 21st st",
   "state": "NY",
   "regions": ["Brooklyn"],
-  postalcode: 11020
+  postalcode: '11020'
 }));
 
 test('754 Pharr Rd, Atlanta, Georgia 31035', expect({
-  number: 754,
+  number: '754',
   street: 'Pharr Rd',
   state: 'GA',
   regions: ['Atlanta'],
-  postalcode: 31035
+  postalcode: '31035'
 }));
 
 test('Texas 76013', expect({
   "state": "TX",
   "regions": [],
-  postalcode: 76013
+  postalcode: '76013'
 }));
 
 test('Dallas', expect({
@@ -63,12 +63,19 @@ test('California', expect({
 test('Santa Monica, California 90407', expect({
   "state": "CA",
   "regions": ["Santa Monica"],
-  postalcode: 90407
+  postalcode: '90407'
 }));
+
 
 test('Grand canyon 86023', expect({
   "regions": ["Grand canyon"],
-  postalcode: 86023
+  postalcode: '86023'
+}));
+
+// don't strip leading 00's from zipcode, those are valid
+test('CT, 06410', expect({
+  "regions": ["CT"],
+  postalcode: '06410'
 }));
 
 // Check behavior with a failing address

--- a/test/parse.js
+++ b/test/parse.js
@@ -5,32 +5,32 @@ function expect(expected) {
 }
 
 test('2649 Logan Road, Eight Mile Plains, QLD', expect({
-  number: 2649,
+  number: '2649',
   street: 'Logan Road',
   regions: ['Eight Mile Plains', 'QLD']
 }));
 
 test('2649 Logan Road Eight Mile Plains, QLD', expect({
-  number: 2649,
+  number: '2649',
   street: 'Logan Road',
   regions: ['Eight Mile Plains', 'QLD']
 }));
 
 test('4 N 2nd St #950, San Jose, CA', expect({
-  unit: 950,
-  number: 4,
+  unit: '950',
+  number: '4',
   street: "N 2nd St",
   regions: ["San Jose"]
 }));
 
 test('1 Queen Street, Brisbane', expect({
-  "number": 1,
+  "number": '1',
   "street": "Queen Street",
   "regions": ["Brisbane"]
 }));
 
 test('754 Robinson Rd West, Aspley, QLD', expect({
-  number: 754,
+  number: '754',
   street: 'Robinson Rd West',
   regions: ['Aspley', 'QLD']
 }));
@@ -44,15 +44,15 @@ test('Perth', expect({
 }));
 
 test('1/135 Ferny Way, Ferny Grove', expect({
-  "unit": 1,
-  "number": 135,
+  "unit": '1',
+  "number": '135',
   "street": "Ferny Way",
   "regions": ["Ferny Grove"]
 }));
 
 test('Shop 8, 431 St Kilda Rd Melbourne', expect({
-  "unit": 8,
-  "number": 431,
+  "unit": '8',
+  "number": '431',
   "street": "St Kilda Rd",
   "regions": ["Melbourne"]
 }));
@@ -72,14 +72,14 @@ test('3N751 Hawthorn Dr., St. Charles, IL', expect({
 }));
 
 test('8/437 St Kilda Road Melbourne, VIC', expect({
-  "unit": 8,
-  "number": 437,
+  "unit": '8',
+  "number": '437',
   "street": "St Kilda Road",
   "regions": ["Melbourne", "VIC"]
 }));
 
 test('18 E. Main St.', expect({
-  "number": 18,
+  "number": '18',
   "street": "E. Main St",
   "regions": []
 }));

--- a/test/street-types.js
+++ b/test/street-types.js
@@ -8,7 +8,7 @@ function valid(t) {
   t.plan(3);
   address = addressit(input);
 
-  t.equal(address.number, 15);
+  t.equal(address.number, '15');
   t.equal(address.street, 'FOO ' + t.name.toUpperCase());
   t.deepEqual(address.regions, ['BARVILLE']);
 }


### PR DESCRIPTION
Many postalcodes start with 0 and the conversion to number is causing them to be stripped.
This effectively changes the postalcode and our geocoder matches the new postalcode somewhere in Europe instead.

Housenumber can also be wacky, so better keep them as strings.

I didn't commit the `dist/` because the differences seemed to be greater than just what I had changed. Let me know if you want me to add that anyway.