### PR TITLE
Recognize TRAIL/TRL Street Suffixes

### DIFF
--- a/parsers/en.js
+++ b/parsers/en.js
@@ -69,6 +69,7 @@ var streetRegexes = compiler([
   'T(ERRA)?CE',           // TERRACE / TCE
   '(THOROUGHFARE|TFRE)',  // THOROUGHFARE / TFRE
   'TRACK?',               // TRACK / TRAC
+  'TR(AI)?L',             // TRAIL / TRL
   'T(RUNK)?WAY',          // TRUNKWAY / TWAY
   // 'VIEW',                 // VIEW
   'VI?STA',               // VISTA / VSTA

--- a/test/locale-en-US.js
+++ b/test/locale-en-US.js
@@ -62,6 +62,14 @@ test('425 W 23rd St, New York, NY 10011', expect({
   postalcode: '10011'
 }));
 
+test('1035 Comanchee Trl, West Columbia, South Carolina 29169', expect({
+  number: '1035',
+  street: 'Comanchee Trl',
+  state: 'SC',
+  regions: ['West Columbia'],
+  postalcode: '29169'
+}));
+
 test('Texas 76013', expect({
   "state": "TX",
   "regions": [],

--- a/test/street-types.js
+++ b/test/street-types.js
@@ -106,6 +106,8 @@ test('THOROUGHFARE', valid);
 test('TFRE', valid);
 test('TRACK', valid);
 test('TRAC', valid);
+test('TRAIL', valid);
+test('TRL', valid);
 test('TRUNKWAY', valid);
 test('TWAY', valid);
 // test('VIEW', valid);


### PR DESCRIPTION
We recently had someone report a bad address parse on [PermitZone](https://app.permitzone.com) where we are using addresit to parse addresses and display relevant parts.

The address they used was `1035 Comanchee Trl, West Columbia, SC 29169` which wasn't registered as a street suffix. This PR adds the TRAIL/TRL street name suffixes and the proper tests for the suffixes and this example.

I found this [US Street Suffix List](http://pe.usps.gov/text/pub28/28apc_002.htm) and it looks like a few more are missing from the parser. I also saw [this note](https://github.com/DamonOehlman/addressit/blob/40654530475b0de0086eea0671e59b954673fd6e/parsers/en.js#L14-L17) about collisions with suburb names. Is #3 a potential solution, or is that unrelated to the suburb name issue?