### PR TITLE
Add fix for Broadway

### DIFF
--- a/address.js
+++ b/address.js
@@ -32,12 +32,11 @@ var proto = Address.prototype;
   start of the parts array is reached or we fall back to non-numeric fields
   then the extraction is stopped.
 **/
-proto._extractStreetParts = function(startIndex, splitStreet) {
+proto._extractStreetParts = function(startIndex, streetPartsLength) {
   var index = startIndex;
   var streetParts = [];
   var numberParts;
   var parts = this.parts;
-  var streetPartsLength = (splitStreet) ? 3 : 2;
   var testFn = function() {
     return true;
   };
@@ -187,10 +186,10 @@ proto.extract = function(fieldName, regexes) {
   This function is used to parse the address parts and locate any parts
   that look to be related to a street address.
 **/
-proto.extractStreet = function(regexes, reSplitStreet) {
+proto.extractStreet = function(regexes, reSplitStreet, reNoStreet) {
   var reNumericesque = /^(\d*|\d*\w)$/;
   var parts = this.parts;
-  var splitStreet = false;
+  var streetPartsLength = 2;
 
   // ensure we have regexes
   regexes = regexes || [];
@@ -233,11 +232,15 @@ proto.extractStreet = function(regexes, reSplitStreet) {
         // address parts are appropriately delimited, then grab the next part
         // also
         if (reSplitStreet.test(parts[startIndex + 1])) {
-          splitStreet = true;
+          streetPartsLength = 3;
           startIndex += 1;
         }
 
-        this._extractStreetParts(startIndex, splitStreet);
+        if (reNoStreet.test(parts[startIndex])) {
+          streetPartsLength = 1;
+        }
+
+        this._extractStreetParts(startIndex, streetPartsLength);
         break;
       } // if
     } // for

--- a/parsers/en.js
+++ b/parsers/en.js
@@ -76,10 +76,12 @@ var streetRegexes = compiler([
   'WALK',                 // WALK
   'WA?Y',                 // WAY / WY
   'W(ALK)?WAY',           // WALKWAY / WWAY
-  'YARD'                  // YARD
+  'YARD',                 // YARD
+  'BROADWAY'
 ]);
 
 var reSplitStreet = /^(N|NTH|NORTH|E|EST|EAST|S|STH|SOUTH|W|WST|WEST)\,$/i;
+var reNoStreet = compiler(['BROADWAY']).pop();
 
 module.exports = function(text, opts) {
   var address = new Address(text, opts);
@@ -108,7 +110,7 @@ module.exports = function(text, opts) {
     ])
 
     // extract the street
-    .extractStreet(streetRegexes, reSplitStreet);
+    .extractStreet(streetRegexes, reSplitStreet, reNoStreet);
 
   if (opts && opts.state) {
     address.extract('state', opts.state );

--- a/test/locale-en-US.js
+++ b/test/locale-en-US.js
@@ -132,3 +132,12 @@ test('Niagara Falls 76B09', expect({
   "regions": ["Niagara Falls 76B09"],
   postalcode: undefined
 }));
+
+// Broadway doesn't have a suffix like "Street" or "Road"
+test('123 Broadway, New York, NY 10010', expect({
+  number: '123',
+  street: 'Broadway',
+  state: 'NY',
+  regions: ['New York'],
+  postalcode: '10010'
+}));


### PR DESCRIPTION
Basic issue I've run across is that "Broadway" is kind of a weird special case where there's no street type (i.e. It's not "Broadway *Road*" or "Broadway *Ave*", it's just "Broadway").

This causes address to parse incorrectly (initially noticed when playing around with Mapzen's `pelias-api`).

Anyway, there might be a better way to go about this, but not really having any familiarity with the codebase, this was what I came up with.