### PR TITLE
Adds Terr and Ter abbreviations for Terrace

### DIFF
--- a/parsers/en.js
+++ b/parsers/en.js
@@ -66,7 +66,7 @@ var streetRegexes = compiler([
   'ST(REET)?',            // STREET / ST
   'STRI?P',               // STRIP / STRP
   'TARN',                 // TARN
-  'T(ERRA)?CE',           // TERRACE / TCE
+  'T(ERRA)?CE|TER?R',     // TERRACE / TER / TERR / TCE
   '(THOROUGHFARE|TFRE)',  // THOROUGHFARE / TFRE
   'TRACK?',               // TRACK / TRAC
   'TR(AI)?L',             // TRAIL / TRL


### PR DESCRIPTION
This PR allows parsing for Terrace abbreviations: Ter and Terr. It should still be able to parse Tce, since it uses the original regex with another two cases.