### PR TITLE
Don't attempt to extract a field multiple times

### DIFF
--- a/address.js
+++ b/address.js
@@ -104,6 +104,10 @@ proto.clean = function(cleaners) {
   from the parts list.
 **/
 proto.extract = function(fieldName, regexes) {
+
+  // skip fields which have already been parsed
+  if (this[fieldName]) { return this; }
+
   var match;
   var rgxIdx;
   var ii;

--- a/address.js
+++ b/address.js
@@ -51,7 +51,7 @@ proto._extractStreetParts = function(startIndex, streetPartsLength) {
     else {
       if (! numberParts) {
         numberParts = [];
-      } // if
+      }
 
       // add the current part to the building parts
       numberParts.unshift(parts.splice(index--, 1));
@@ -64,7 +64,7 @@ proto._extractStreetParts = function(startIndex, streetPartsLength) {
         // for non-alpha values, otherwise alpha
         return numberParts ? (! isAlpha) : isAlpha;
       };
-    } // if..else
+    }
   } // while
 
   this.number = numberParts ? numberParts.join('/') : '';
@@ -90,7 +90,7 @@ proto.clean = function(cleaners) {
     else if (cleaners[ii] instanceof RegExp) {
       this.text = this.text.replace(cleaners[ii], '');
     }
-  } // for
+  }
 
   return this;
 };
@@ -142,11 +142,11 @@ proto.extract = function(fieldName, regexes) {
         } else {
           // otherwise, just remove the element from parts
           this.parts.splice(ii, 1);
-        } // if..else
+        }
 
         // set the field
         this[fieldName] = lookups[rgxIdx] || match[1];
-      } // if
+      }
 
       // special case for states
       // @todo: add code comments
@@ -173,15 +173,15 @@ proto.extract = function(fieldName, regexes) {
             else {
               this.parts.splice(ii - spacesInMatch + 1, spacesInMatch);
               ii -= spacesInMatch + 1;
-            } // if..else
+            }
 
             // set the field
             this[fieldName] = lookups[rgxIdx] || matchMultiplePart[1];
           }
         }
-      } // if
-    } // for
-  } // for
+      }
+    }
+  }
 
   return this;
 };
@@ -218,9 +218,9 @@ proto.extractStreet = function(regexes, reSplitStreet, reNoStreet) {
           // update the best index and break from the inner loop
           bestIndex = ii;
           break;
-        } // if
-      } // for
-    } // for
+        }
+      }
+    }
 
     return bestIndex;
   } // locateBestStreetPart
@@ -248,9 +248,9 @@ proto.extractStreet = function(regexes, reSplitStreet, reNoStreet) {
 
         this._extractStreetParts(startIndex, streetPartsLength);
         break;
-      } // if
-    } // for
-  } // for
+      }
+    }
+  }
 
   return this;
 };
@@ -286,8 +286,8 @@ proto.split = function(separator) {
   for (var ii = 0; ii < newParts.length; ii++) {
     if (newParts[ii]) {
       this.parts[this.parts.length] = newParts[ii];
-    } // if
-  } // for
+    }
+  }
 
   return this;
 };
@@ -302,7 +302,7 @@ proto.toString = function() {
 
   if (this.building) {
     output += this.building + '\n';
-  } // if
+  }
 
   if (this.street) {
     output += this.number ? this.number + ' ' : '';

--- a/test/locale-en-US.js
+++ b/test/locale-en-US.js
@@ -141,3 +141,12 @@ test('123 Broadway, New York, NY 10010', expect({
   regions: ['New York'],
   postalcode: '10010'
 }));
+
+// Only parse the state once, do not modify 'Mt Tabor Park' to remove 'MT'.
+test('Mt Tabor Park, 6220 SE Salmon St, Portland, OR 97215, USA', expect({
+  number: '6220',
+  street: 'SE Salmon St',
+  state: 'OR',
+  country: 'USA',
+  regions: ['Mt Tabor Park', 'Portland', '97215']
+}));


### PR DESCRIPTION
With a query such as "Mt Tabor Park, 6220 SE Salmon St, Portland, OR 97215, USA", the state is detected twice.
Once as `MT` and once as `OR`.

With the existing logic, the state is correctly set as `OR` but the place name is truncated, becoming `Tabor Park` instead of `Mt Tabor Park`.
This PR ensures that the state is only parsed once, and it doesn't modify tokens on subsequent regexes matching on state.

I've switched the loops around, looping through the `parts` in reverse order in the outer loop and then doing the regex matching on the inner loop.
I'd expect there to be a performance benefit from doing it like this and skipping a bunch of iterations, plus it allows us to check what parts have already been solved.

I've also removed the variable `value`, I'm not sure what exactly the purpose of that was, there were also no code comments about what it's supposed to be doing, so I simplified things by removing it.