### PR TITLE
do not parse first token as state abbreviation

### DIFF
--- a/address.js
+++ b/address.js
@@ -134,6 +134,15 @@ proto.extract = function(fieldName, regexes) {
       // skip fields which have already been parsed
       if (this[fieldName]){ continue; }
 
+      // do not consider the first token for an abbreviated 'state' field
+      if (ii === 0 && fieldName === 'state'){
+        // only where there are more than one token and the first token
+        // is less than or equal to three characters in length.
+        if ( this.parts.length > 1 && this.parts[ii].length <= 3 ) {
+          continue;
+        }
+      }
+
       // execute regex against part
       match = regexes[rgxIdx].exec(this.parts[ii]);
 

--- a/address.js
+++ b/address.js
@@ -104,6 +104,10 @@ proto.clean = function(cleaners) {
   from the parts list.
 **/
 proto.extract = function(fieldName, regexes) {
+
+  // skip fields which have already been parsed
+  if (this[fieldName]) { return this; }
+
   var match;
   var rgxIdx;
   var ii;

--- a/address.js
+++ b/address.js
@@ -51,7 +51,7 @@ proto._extractStreetParts = function(startIndex, streetPartsLength) {
     else {
       if (! numberParts) {
         numberParts = [];
-      } // if
+      }
 
       // add the current part to the building parts
       numberParts.unshift(parts.splice(index--, 1));
@@ -64,7 +64,7 @@ proto._extractStreetParts = function(startIndex, streetPartsLength) {
         // for non-alpha values, otherwise alpha
         return numberParts ? (! isAlpha) : isAlpha;
       };
-    } // if..else
+    }
   } // while
 
   this.number = numberParts ? numberParts.join('/') : '';
@@ -90,7 +90,7 @@ proto.clean = function(cleaners) {
     else if (cleaners[ii] instanceof RegExp) {
       this.text = this.text.replace(cleaners[ii], '');
     }
-  } // for
+  }
 
   return this;
 };
@@ -142,11 +142,11 @@ proto.extract = function(fieldName, regexes) {
         } else {
           // otherwise, just remove the element from parts
           this.parts.splice(ii, 1);
-        } // if..else
+        }
 
         // set the field
         this[fieldName] = lookups[rgxIdx] || match[1];
-      } // if
+      }
 
       // special case for states
       // @todo: add code comments
@@ -173,15 +173,15 @@ proto.extract = function(fieldName, regexes) {
             else {
               this.parts.splice(ii - spacesInMatch + 1, spacesInMatch);
               ii -= spacesInMatch + 1;
-            } // if..else
+            }
 
             // set the field
             this[fieldName] = lookups[rgxIdx] || matchMultiplePart[1];
           }
         }
-      } // if
-    } // for
-  } // for
+      }
+    }
+  }
 
   return this;
 };
@@ -218,9 +218,9 @@ proto.extractStreet = function(regexes, reSplitStreet, reNoStreet) {
           // update the best index and break from the inner loop
           bestIndex = ii;
           break;
-        } // if
-      } // for
-    } // for
+        }
+      }
+    }
 
     return bestIndex;
   } // locateBestStreetPart
@@ -248,9 +248,9 @@ proto.extractStreet = function(regexes, reSplitStreet, reNoStreet) {
 
         this._extractStreetParts(startIndex, streetPartsLength);
         break;
-      } // if
-    } // for
-  } // for
+      }
+    }
+  }
 
   return this;
 };
@@ -286,8 +286,8 @@ proto.split = function(separator) {
   for (var ii = 0; ii < newParts.length; ii++) {
     if (newParts[ii]) {
       this.parts[this.parts.length] = newParts[ii];
-    } // if
-  } // for
+    }
+  }
 
   return this;
 };
@@ -302,7 +302,7 @@ proto.toString = function() {
 
   if (this.building) {
     output += this.building + '\n';
-  } // if
+  }
 
   if (this.street) {
     output += this.number ? this.number + ' ' : '';

--- a/test/locale-en-US.js
+++ b/test/locale-en-US.js
@@ -150,3 +150,13 @@ test('Mt Tabor Park, 6220 SE Salmon St, Portland, OR 97215, USA', expect({
   country: 'USA',
   regions: ['Mt Tabor Park', 'Portland', '97215']
 }));
+
+// Do not parse the first token as a state abbreviation
+test('Mt Tabor Park', expect({
+  regions: ['Mt Tabor Park']
+}));
+
+// Parse the first token as a state abbreviation when only one token present
+test('Mt', expect({
+  state: 'MT'
+}));

--- a/test/locale-en-US.js
+++ b/test/locale-en-US.js
@@ -141,3 +141,12 @@ test('123 Broadway, New York, NY 10010', expect({
   regions: ['New York'],
   postalcode: '10010'
 }));
+
+// Only parse the state once, do not modify 'Mt Tabor Park' to remove 'MT'.
+test('Mt Tabor Park, 6220 SE Salmon St, Portland, OR 97215, USA', expect({
+  number: '6220',
+  street: 'SE Salmon St',
+  state: 'OR',
+  country: 'USA',
+  regions: ['Mt Tabor Park', 'Portland', '97215']
+}));


### PR DESCRIPTION
Note: branched off https://github.com/DamonOehlman/addressit/pull/25, you can [view just the difference between the branches here](https://github.com/missinglink/addressit/compare/only_extract_field_once...missinglink:do_not_parse_first_token_as_state_abbr).

This PR fixes an issue where the user was entering the name of a park `Mt Tabor Park` and it was being parsed as `Tabor Park` in `MT` (Montana).
It's a difficult case to handle, so this PR adds a pretty simple fix, based off an assumption that if there are multiple tokens, then it's extremely unlikely for the first token to be a two-letter state abbreviation.

I guess this is also a problem for places like `Au Rolay` (Belgium) as there is a risk that the first token is parsed as `Auatralia`

